### PR TITLE
Fix: call_user_func_array() error PHP 8.1

### DIFF
--- a/faker/ContentContainerProvider.php
+++ b/faker/ContentContainerProvider.php
@@ -11,7 +11,7 @@ class ContentContainerProvider extends Base
 
     public static $index = 0;
 
-    public function createContainer($class, $id)
+    public static function createContainer($class, $id)
     {
         $result =  [
             'id' => ++static::$index,


### PR DESCRIPTION
This temporarily fixes an error where when using PHP 8.1+ generating the following error.

```log
TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, non-static method humhub\modules\profiler\faker\ContentContainerProvider::createContainer() cannot be called statically in /home/greenmet/public_html/protected/vendor/fakerphp/faker/src/Faker/Generator.php:696
```